### PR TITLE
[FEAT/#5] 초기 상태 측정 대기 화면 구현

### DIFF
--- a/app/src/main/java/com/haeti/ddolie/presentation/common/component/CtaButton.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/common/component/CtaButton.kt
@@ -1,0 +1,61 @@
+package com.haeti.ddolie.presentation.common.component
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableLongStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Chip
+import androidx.wear.compose.material.ChipDefaults
+import androidx.wear.compose.material.Text
+import com.haeti.ddolie.presentation.common.util.toTextDp
+import com.haeti.ddolie.presentation.theme.DdoLieTheme
+
+@Composable
+fun CtaButton(
+    text: String,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit = {},
+    chipColor: Color = DdoLieTheme.colors.redPrimary,
+    contentColor: Color = DdoLieTheme.colors.white,
+) {
+    val lastClickTime = remember { mutableLongStateOf(0L) }
+
+    val throttledClick: () -> Unit = {
+        val currentTime: Long = System.currentTimeMillis()
+        if (currentTime - lastClickTime.longValue >= 500L) {
+            onClick()
+            lastClickTime.longValue = currentTime
+        }
+    }
+
+    Chip(
+        onClick = throttledClick,
+        colors = ChipDefaults.primaryChipColors(
+            backgroundColor = chipColor,
+            contentColor = contentColor,
+        ),
+        label = {
+            Text(
+                text = text,
+                textAlign = TextAlign.Center,
+                fontSize = 18.toTextDp,
+                fontWeight = FontWeight.SemiBold,
+            )
+        },
+        contentPadding = PaddingValues(horizontal = 25.dp, vertical = 10.dp),
+        shape = RoundedCornerShape(360.dp),
+    )
+}
+
+@Preview
+@Composable
+fun CtaButtonPreview() {
+    CtaButton(text = "시작하기", onClick = {})
+}

--- a/app/src/main/java/com/haeti/ddolie/presentation/init/InitialScreen.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/init/InitialScreen.kt
@@ -1,6 +1,8 @@
 package com.haeti.ddolie.presentation.init
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -8,6 +10,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
@@ -15,25 +19,51 @@ import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.haeti.ddolie.presentation.common.component.CtaButton
 import com.haeti.ddolie.presentation.common.util.toTextDp
+import kotlin.math.cos
+import kotlin.math.sin
 
 @Composable
 fun InitialScreen() {
-    Column(
-        modifier = Modifier.fillMaxSize(),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        Text(
-            text = "거짓말 탐지 전\n상태를 측정하세요",
-            fontSize = 20.toTextDp,
-            fontWeight = FontWeight.SemiBold,
-            lineHeight = 30.toTextDp,
-            textAlign = TextAlign.Center
-        )
+    val circleColor = Color(0xFFF44522)
+    val circleRadius = 6f
 
-        Spacer(modifier = Modifier.height(18.dp))
+    Box(modifier = Modifier.fillMaxSize()) {
+        Canvas(modifier = Modifier.fillMaxSize()) {
+            val centerX = size.width / 2
+            val centerY = size.height / 2
+            val radius = size.minDimension * 0.47f
 
-        CtaButton(text = "시작하기")
+            for (i in 0 until 8) {
+                val angle = Math.toRadians(270.0 + i * 45.0).toFloat()
+
+                val x = centerX + (cos(angle) * radius)
+                val y = centerY + (sin(angle) * radius)
+
+                drawCircle(
+                    color = circleColor,
+                    radius = circleRadius * density,
+                    center = Offset(x, y)
+                )
+            }
+        }
+
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "거짓말 탐지 전\n상태를 측정하세요",
+                fontSize = 20.toTextDp,
+                fontWeight = FontWeight.SemiBold,
+                lineHeight = 30.toTextDp,
+                textAlign = TextAlign.Center
+            )
+
+            Spacer(modifier = Modifier.height(18.dp))
+
+            CtaButton(text = "시작하기")
+        }
     }
 }
 

--- a/app/src/main/java/com/haeti/ddolie/presentation/init/InitialScreen.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/init/InitialScreen.kt
@@ -1,0 +1,44 @@
+package com.haeti.ddolie.presentation.init
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.wear.compose.material.Text
+import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
+import com.haeti.ddolie.presentation.common.component.CtaButton
+import com.haeti.ddolie.presentation.common.util.toTextDp
+
+@Composable
+fun InitialScreen() {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = "거짓말 탐지 전\n상태를 측정하세요",
+            fontSize = 20.toTextDp,
+            fontWeight = FontWeight.SemiBold,
+            lineHeight = 30.toTextDp,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(18.dp))
+
+        CtaButton(text = "시작하기")
+    }
+}
+
+@WearPreviewDevices
+@Composable
+fun InitialScreenPreview() {
+    InitialScreen()
+}

--- a/app/src/main/java/com/haeti/ddolie/presentation/init/navigation/InitialNavigation.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/init/navigation/InitialNavigation.kt
@@ -1,0 +1,11 @@
+package com.haeti.ddolie.presentation.init.navigation
+
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.compose.composable
+import com.haeti.ddolie.presentation.init.InitialScreen
+
+fun NavGraphBuilder.addInitialGraph() {
+    composable<InitialRoute.Main> {
+        InitialScreen()
+    }
+}

--- a/app/src/main/java/com/haeti/ddolie/presentation/init/navigation/InitialRoute.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/init/navigation/InitialRoute.kt
@@ -1,0 +1,10 @@
+package com.haeti.ddolie.presentation.init.navigation
+
+import com.haeti.ddolie.presentation.navigation.NavRoute
+import kotlinx.serialization.Serializable
+
+@Serializable
+sealed interface InitialRoute : NavRoute {
+    @Serializable
+    data object Main : InitialRoute
+}

--- a/app/src/main/java/com/haeti/ddolie/presentation/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/navigation/AppNavHost.kt
@@ -6,22 +6,24 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
+import com.haeti.ddolie.presentation.init.navigation.addInitialGraph
 import com.haeti.ddolie.presentation.start.navigation.addStartGraph
 
 @Composable
 fun AppNavHost(
-	navController: NavController,
-	modifier: Modifier = Modifier,
-	navigator: AppNavigator,
+    navController: NavController,
+    modifier: Modifier = Modifier,
+    navigator: AppNavigator,
 ) {
-	Box (
-		modifier = modifier.fillMaxSize(),
-	){
-		NavHost(
-			navController = navigator.navController,
-			startDestination = navigator.startDestination,
-		) {
-			addStartGraph()
-		}
-	}
+    Box(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        NavHost(
+            navController = navigator.navController,
+            startDestination = navigator.startDestination,
+        ) {
+            addStartGraph(navController)
+            addInitialGraph()
+        }
+    }
 }

--- a/app/src/main/java/com/haeti/ddolie/presentation/start/StartScreen.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/start/StartScreen.kt
@@ -2,6 +2,7 @@ package com.haeti.ddolie.presentation.start
 
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -19,20 +20,28 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
+import androidx.navigation.compose.rememberNavController
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.haeti.ddolie.R
 import com.haeti.ddolie.presentation.common.util.toTextDp
+import com.haeti.ddolie.presentation.init.navigation.InitialRoute
 import com.haeti.ddolie.presentation.theme.DdoLieTheme
 
 @Composable
-fun StartScreen() {
+fun StartScreen(
+    navController: NavController,
+) {
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .clickable { navController.navigate(InitialRoute.Main) },
         contentAlignment = Alignment.Center,
     ) {
         Box(
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier
+                .fillMaxSize()
                 .background(
                     brush = Brush.radialGradient(
                         colors = listOf(
@@ -90,6 +99,6 @@ fun StartScreen() {
 @Composable
 fun PreviewStartScreen() {
     DdoLieTheme {
-        StartScreen()
+        StartScreen(navController = rememberNavController())
     }
 }

--- a/app/src/main/java/com/haeti/ddolie/presentation/start/navigation/StartNavigation.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/start/navigation/StartNavigation.kt
@@ -1,11 +1,12 @@
 package com.haeti.ddolie.presentation.start.navigation
 
+import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.haeti.ddolie.presentation.start.StartScreen
 
-fun NavGraphBuilder.addStartGraph() {
-	composable<StartRoute.Main> {
-		StartScreen()
-	}
+fun NavGraphBuilder.addStartGraph(navController: NavController) {
+    composable<StartRoute.Main> {
+        StartScreen(navController)
+    }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/210bb8bc-237e-453a-82b7-97f906f167e0)

## 요약
- 재사용을 위한 CTA 버튼 컴포넌트 구현
- 초기 상태 측정 대기 화면 구현

## ⭐ 삼각함수를 활용한 원형 배치
- 워치의 테두리를 
- 따라 원들을 배치할 때 삼각함수를 활용하였다.

### Canvas 활용
1. Canvas를 워치 전체 영역으로 선언하였다. 따라서 여기서 size.width와 height는 캔버스의 너비와 높이를 나타낸다. 
2. size.minDimension은 너비와 높이 중 작은 값을 반환한다. 워치는 일반적으로 원형이므로, 화면 반지름을 구할 수 있다. 
3. density는 화면의 픽셀 밀도를 나타내는 값이다. 이를 곱함으로써 조금 더 일관적인 사이즈의 원을 그릴 수 있다.

### 등간격 각도 계산
- 원을 8등분 하므로 각 원 사이 각도는 360 / 8 = 45° 이다.
- 12시 방향은 270°이고 여기부터 그리기 시작했다. 45° 간격으로 증가시키면서 각도를 변경한다.
- 각도를 라디안으로 변경하여 삼각함수에서 활용한다

![image](https://github.com/user-attachments/assets/840853f2-9b76-45e2-93d8-594b961c8edb)
- 원의 중심에서 특정 각도로 radius만큼 떨어진 점의 좌표를 다음과 같이 구할 수 있다. 
- x = centerX + cos(angle) * radius
- y = centerY + sin(angle) * radius


## 알게된 점
- Wear OS의 Button은 타원형으로 만들 수 없다. 기존의 Compose에서 타원형 버튼을 쓰던 것을, wear.compose.material에서는 Chip으로 구현하는 것이 좋을 것 같다. 
- 워치는 일반적으로 원형이므로 삼각함수를 활용한 배치를 할 경우가 꽤 많을 것 같다.