### PR TITLE
[Refactor/#20] 시작 화면 기기대응

### DIFF
--- a/app/src/main/java/com/haeti/ddolie/presentation/start/StartScreen.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/start/StartScreen.kt
@@ -47,9 +47,28 @@ fun StartScreen(
             .clickable { navController.navigate(InitialRoute.Main) },
         contentAlignment = Alignment.Center
     ) {
+        val screenWidthDp = maxWidth
+
+        // 44mm 화면 기준
+        val baseWidthDp = 218.dp
+
+        val scale = screenWidthDp / baseWidthDp
+
+        val baseImageWidth  = 108.dp
+        val baseImageHeight = 70.dp
+        val imageWidth  = baseImageWidth  * scale
+        val imageHeight = baseImageHeight * scale
+
+        val baseFontSize  = 15.toTextDp
+        val baseLineHeight = 23.toTextDp
+        val fontSize   = baseFontSize * scale
+        val lineHeight = baseLineHeight * scale
+
+        val baseSpacer = 10.dp
+        val spacerHeight = baseSpacer * scale
 
         Box(
-            modifier = Modifier.size(maxWidth),
+            modifier = Modifier.size(screenWidthDp),
             contentAlignment = Alignment.Center
         ) {
             Canvas(modifier = Modifier.matchParentSize()) {
@@ -71,7 +90,6 @@ fun StartScreen(
                 drawCircle(color = RedPrimary, radius = radiusPx * 0.75f)
             }
 
-
             Column(
                 modifier = Modifier.fillMaxSize(),
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -80,16 +98,16 @@ fun StartScreen(
                 Image(
                     painter = painterResource(R.drawable.img_logo),
                     contentDescription = "logo",
-                    modifier = Modifier.size(width = 108.dp, height = 70.dp)
+                    modifier = Modifier.size(width = imageWidth, height = imageHeight)
                 )
 
-                Spacer(Modifier.height(10.dp))
+                Spacer(Modifier.height(spacerHeight))
 
                 Text(
                     text = "시작하려면 화면을\n터치해주세요",
-                    fontSize = 15.toTextDp,
+                    fontSize = fontSize,
                     fontWeight = FontWeight.Bold,
-                    lineHeight = 23.toTextDp,
+                    lineHeight = lineHeight,
                     textAlign = TextAlign.Center
                 )
             }

--- a/app/src/main/java/com/haeti/ddolie/presentation/start/StartScreen.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/start/StartScreen.kt
@@ -1,101 +1,110 @@
 package com.haeti.ddolie.presentation.start
 
+import android.annotation.SuppressLint
+import android.content.res.Configuration
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import androidx.navigation.NavController
 import androidx.navigation.compose.rememberNavController
 import androidx.wear.compose.material.Text
 import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.haeti.ddolie.R
+import com.haeti.ddolie.presentation.common.util.toTextDp
 import com.haeti.ddolie.presentation.init.navigation.InitialRoute
 import com.haeti.ddolie.presentation.theme.DdoLieTheme
+import com.haeti.ddolie.presentation.theme.RedPrimary
+import com.haeti.ddolie.presentation.theme.RedSecondary
+import com.haeti.ddolie.presentation.theme.RedTertiary
 
+@SuppressLint("UnusedBoxWithConstraintsScope")
 @Composable
 fun StartScreen(
     navController: NavController,
 ) {
-    Box(
+    BoxWithConstraints(
         modifier = Modifier
             .fillMaxSize()
             .clickable { navController.navigate(InitialRoute.Main) },
-        contentAlignment = Alignment.Center,
+        contentAlignment = Alignment.Center
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(
-                    brush = Brush.radialGradient(
-                        colors = listOf(
-                            DdoLieTheme.colors.redTertiary,
-                            Color.Transparent
-                        )
-                    ),
-                    shape = CircleShape
-                )
-        )
 
         Box(
-            modifier = Modifier
-                .size((172 + 46).dp)
-                .background(
-                    color = DdoLieTheme.colors.redSecondary,
-                    shape = CircleShape
-                )
-        )
-
-        Box(
-            modifier = Modifier
-                .size(172.dp)
-                .background(
-                    color = DdoLieTheme.colors.redPrimary,
-                    shape = CircleShape,
-                )
-        )
-
-        Column(
-            modifier = Modifier.fillMaxSize(),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center
+            modifier = Modifier.size(maxWidth),
+            contentAlignment = Alignment.Center
         ) {
-            Image(
-                painter = painterResource(R.drawable.img_logo),
-                contentDescription = "logo",
-                modifier = Modifier.size(width = 108.dp, height = 70.dp)
-            )
+            Canvas(modifier = Modifier.matchParentSize()) {
+                val radiusPx = size.width / 2f
+                val center = Offset(radiusPx, radiusPx)
 
-            Spacer(Modifier.height(10.dp))
+                val gradientBrush = Brush.radialGradient(
+                    colorStops = arrayOf(
+                        0.00f to RedTertiary,
+                        0.85f to RedTertiary,
+                        1.00f to Color.Black
+                    ),
+                    center = center,
+                    radius = radiusPx
+                )
+                drawCircle(brush = gradientBrush, radius = radiusPx)
 
-            Text(
-                text = "시작하려면 화면을\n터치해주세요",
-                fontSize = 15.sp,
-                fontWeight = FontWeight.Bold,
-                lineHeight = 23.sp,
-                textAlign = TextAlign.Center
-            )
+                drawCircle(color = RedSecondary, radius = radiusPx * 0.95f)
+                drawCircle(color = RedPrimary, radius = radiusPx * 0.75f)
+            }
+
+
+            Column(
+                modifier = Modifier.fillMaxSize(),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center
+            ) {
+                Image(
+                    painter = painterResource(R.drawable.img_logo),
+                    contentDescription = "logo",
+                    modifier = Modifier.size(width = 108.dp, height = 70.dp)
+                )
+
+                Spacer(Modifier.height(10.dp))
+
+                Text(
+                    text = "시작하려면 화면을\n터치해주세요",
+                    fontSize = 15.toTextDp,
+                    fontWeight = FontWeight.Bold,
+                    lineHeight = 23.toTextDp,
+                    textAlign = TextAlign.Center
+                )
+            }
         }
     }
 }
 
 @WearPreviewDevices
+@Preview(
+    name = "40mm – 396×396px",
+    device = "spec:width=396px,height=396px,dpi=330", // 40mm 모델 테스트
+    uiMode = Configuration.UI_MODE_TYPE_WATCH,
+    showSystemUi = false,
+    showBackground = false
+)
 @Composable
 fun PreviewStartScreen() {
     DdoLieTheme {


### PR DESCRIPTION
## 작업 내용
- 기기 사이즈와 베젤 영역을 고려하여 기존 배경 원을 Canvas와 radius를 사용하여 리펙토링 함
- 마지막 원 레이어에는 그라디언트 효과를 부여 함
- 텍스트 크기가 가장 안쪽 원을 초과하는 경우를 방지하기 위해, 44mm 기기(워치 평균 크기) 기준으로 텍스트 폰트 크기와 이미지 크기를 스케일링 함

## 프리뷰
![image](https://github.com/user-attachments/assets/479587d1-ef6a-4b12-a5e5-ae8a049499c3)
