### PR TITLE
심박 측정 파이프라인 안정화

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,15 @@
 .externalNativeBuild
 .cxx
 local.properties
+
+# IDE
+/.idea/markdown.xml
+
+# OMC artifacts/state
+/.omc/
+
+# Build outputs
+/app/release/
+
+# Signing keystores
+*.jks

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.haeti.ddolie"
         minSdk = 30
         targetSdk = 35
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = 2
+        versionName = "1.1"
 
     }
 

--- a/app/src/main/java/com/haeti/ddolie/presentation/common/manager/HealthServiceManager.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/common/manager/HealthServiceManager.kt
@@ -12,37 +12,42 @@ import androidx.health.services.client.data.DeltaDataType
 import androidx.health.services.client.data.SampleDataPoint
 import androidx.health.services.client.getCapabilities
 import androidx.health.services.client.unregisterMeasureCallback
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.NonCancellable
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.channels.trySendBlocking
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.callbackFlow
-import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.flow.shareIn
+import kotlinx.coroutines.launch
 
 class HealthServiceManager(context: Context) {
     private val measureClient = HealthServices.getClient(context).measureClient
+    private val cleanupScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 
     suspend fun hasHeartRateCapability() = runCatching {
         val capabilities = measureClient.getCapabilities()
         (DataType.HEART_RATE_BPM in capabilities.supportedDataTypesMeasure)
     }.getOrDefault(false)
 
-    fun heartRateMeasureFlow(): Flow<MeasureMessage> = callbackFlow {
+    private val rawFlow: Flow<MeasureMessage> = callbackFlow {
         val callback = object : MeasureCallback {
             override fun onAvailabilityChanged(
                 dataType: DeltaDataType<*, *>,
                 availability: Availability,
             ) {
                 if (availability is DataTypeAvailability) {
+                    Log.d("DdoLieFlow", "availability=$availability")
                     trySendBlocking(MeasureMessage.MeasureAvailability(availability))
                 }
             }
 
             override fun onDataReceived(data: DataPointContainer) {
                 val heartRateBpm = data.getData(DataType.HEART_RATE_BPM)
-                Log.e(
-                    "HeartServiceManager",
-                    "Heart rate data received: ${heartRateBpm.first().value}"
-                )
+                if (heartRateBpm.isEmpty()) return
                 trySendBlocking(MeasureMessage.MeasureData(heartRateBpm))
             }
         }
@@ -50,11 +55,22 @@ class HealthServiceManager(context: Context) {
         measureClient.registerMeasureCallback(DataType.HEART_RATE_BPM, callback)
 
         awaitClose {
-            runBlocking {
+            cleanupScope.launch(NonCancellable) {
                 measureClient.unregisterMeasureCallback(DataType.HEART_RATE_BPM, callback)
             }
         }
     }
+
+    // 두 측정 phase가 동일 등록을 공유하도록 shareIn.
+    // WhileSubscribed(stopTimeoutMillis=15000) → 마지막 구독자 해제 후 15초 동안
+    // 등록을 유지하므로 phase 사이 warm-up이 다시 일어나지 않는다.
+    private val sharedFlow: Flow<MeasureMessage> = rawFlow.shareIn(
+        scope = cleanupScope,
+        started = SharingStarted.WhileSubscribed(stopTimeoutMillis = 15_000),
+        replay = 0,
+    )
+
+    fun heartRateMeasureFlow(): Flow<MeasureMessage> = sharedFlow
 }
 
 sealed class MeasureMessage {

--- a/app/src/main/java/com/haeti/ddolie/presentation/common/util/DdoLieConstants.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/common/util/DdoLieConstants.kt
@@ -2,7 +2,7 @@ package com.haeti.ddolie.presentation.common.util
 
 object DdoLieConstants {
     object Measurement {
-        const val INITIAL_MEASUREMENT_TIMEOUT = 4000L
+        const val INITIAL_MEASUREMENT_TIMEOUT = 5000L
         const val FINALIZE_DELAY = 5000L
         const val HEART_RATE_MIN_THRESHOLD = 0.0
     }
@@ -19,5 +19,7 @@ object DdoLieConstants {
         const val INITIAL_SCREEN_CYCLE_STEPS = 8
         const val INITIAL_SCREEN_STEP_DELAY = 125L
         const val DOT_PHASES_COUNT = 3
+        const val FADE_TRANSITION_MS = 400
+        const val INITIAL_CIRCLE_CYCLE_MS = 1000
     }
 }

--- a/app/src/main/java/com/haeti/ddolie/presentation/common/viewmodel/DdoLieViewModel.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/common/viewmodel/DdoLieViewModel.kt
@@ -1,5 +1,6 @@
 package com.haeti.ddolie.presentation.common.viewmodel
 
+import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.haeti.ddolie.presentation.common.base.BaseViewModel
 import com.haeti.ddolie.presentation.common.contract.DdoLieIntent
@@ -11,9 +12,11 @@ import com.haeti.ddolie.presentation.common.manager.MeasureMessage
 import com.haeti.ddolie.presentation.common.util.DdoLieConstants.Measurement.FINALIZE_DELAY
 import com.haeti.ddolie.presentation.common.util.DdoLieConstants.Measurement.HEART_RATE_MIN_THRESHOLD
 import com.haeti.ddolie.presentation.common.util.DdoLieConstants.Measurement.INITIAL_MEASUREMENT_TIMEOUT
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withTimeout
 import kotlin.random.Random
@@ -22,7 +25,27 @@ class DdoLieViewModel(
     private val healthServiceManager: HealthServiceManager,
 ) : BaseViewModel<DdoLieIntent, DdoLieState, DdoLieSideEffect>(DdoLieState()) {
     var measurementJob: Job? = null
+    private var prewarmJob: Job? = null
     val heartRates = mutableListOf<Double>()
+
+    fun startPrewarm() {
+        if (prewarmJob?.isActive == true) return
+        prewarmJob = viewModelScope.launch {
+            healthServiceManager.heartRateMeasureFlow()
+                .flowOn(Dispatchers.Default)
+                .collect { /* discard, just keep registration warm */ }
+        }
+    }
+
+    fun stopPrewarm() {
+        prewarmJob?.cancel()
+        prewarmJob = null
+    }
+
+    private companion object {
+        const val TAG = "DdoLieFlow"
+        const val BASELINE_FALLBACK_SAMPLES = 2
+    }
 
     override fun onIntent(intent: DdoLieIntent) {
         when (intent) {
@@ -45,18 +68,26 @@ class DdoLieViewModel(
     }
 
     private fun startInitialMeasurement() {
+        measurementJob?.cancel()
+        heartRates.clear()
+        intent {
+            copy(initialHeartRateAvg = null, finalHeartRateAvg = null, isLie = null)
+        }
+
         viewModelScope.launch {
-            val heartRates = mutableListOf<Double>()
+            val initialSamples = mutableListOf<Double>()
 
             try {
                 withTimeout(INITIAL_MEASUREMENT_TIMEOUT) {
                     healthServiceManager.heartRateMeasureFlow()
+                        .flowOn(Dispatchers.Default)
                         .collect { message ->
                             when (message) {
                                 is MeasureMessage.MeasureData -> {
+                                    if (message.data.isEmpty()) return@collect
                                     val lastValue = message.data.last().value
                                     if (lastValue > HEART_RATE_MIN_THRESHOLD) {
-                                        heartRates.add(lastValue)
+                                        initialSamples.add(lastValue)
                                     }
                                 }
 
@@ -70,7 +101,9 @@ class DdoLieViewModel(
                 // 타임아웃 처리
             }
 
-            val average = if (heartRates.isNotEmpty()) heartRates.average().toFloat() else null
+            val average =
+                if (initialSamples.isNotEmpty()) initialSamples.average().toFloat() else null
+            Log.d(TAG, "[1/3] 초기 측정 - samples=${initialSamples.size}, avg=$average")
             intent { copy(initialHeartRateAvg = average) }
             postSideEffect(DdoLieSideEffect.NavigateToVoiceRecognition)
         }
@@ -81,9 +114,11 @@ class DdoLieViewModel(
 
         measurementJob = viewModelScope.launch {
             healthServiceManager.heartRateMeasureFlow()
+                .flowOn(Dispatchers.Default)
                 .collect { message ->
                     when (message) {
                         is MeasureMessage.MeasureData -> {
+                            if (message.data.isEmpty()) return@collect
                             val lastValue = message.data.last().value
                             if (lastValue > HEART_RATE_MIN_THRESHOLD) {
                                 heartRates.add(lastValue)
@@ -107,22 +142,41 @@ class DdoLieViewModel(
             delay(FINALIZE_DELAY)
             measurementJob?.cancel()
 
-            // 피크 기반 차이 계산
-            val maxHeartRate = if (heartRates.isNotEmpty()) {
-                heartRates.maxOrNull()?.toFloat()
+            val initialAvgFromState = currentState.initialHeartRateAvg
+
+            // 초기 측정이 비어있으면 분석 측정 앞쪽 2개를 baseline으로 사용.
+            val baselineFromAnalysis = if (initialAvgFromState == null) {
+                heartRates.take(BASELINE_FALLBACK_SAMPLES)
+                    .takeIf { it.isNotEmpty() }
+                    ?.average()
+                    ?.toFloat()
             } else null
 
-            val initialAvg = currentState.initialHeartRateAvg
-            val diff = if (initialAvg != null && maxHeartRate != null) {
-                maxHeartRate - initialAvg
+            val effectiveInitialAvg = initialAvgFromState ?: baselineFromAnalysis
+
+            // baseline을 분석에서 떼어왔으면 그만큼 비교 set에서 제외
+            val comparisonSet = if (baselineFromAnalysis != null) {
+                heartRates.drop(BASELINE_FALLBACK_SAMPLES)
+            } else {
+                heartRates
+            }
+
+            val maxHeartRate = comparisonSet.maxOrNull()?.toFloat()
+            val diff = if (effectiveInitialAvg != null && maxHeartRate != null) {
+                maxHeartRate - effectiveInitialAvg
             } else 0f
+
+            val finalAvg = if (heartRates.isNotEmpty()) heartRates.average().toFloat() else null
+            Log.d(
+                TAG,
+                "[2/3] 분석 측정 - samples=${heartRates.size}, avg=$finalAvg, max=$maxHeartRate, baselineFallback=$baselineFromAnalysis",
+            )
 
             val result = determineLieResult(diff)
 
-            val finalAvg = if (heartRates.isNotEmpty()) heartRates.average().toFloat() else null
-
             intent { copy(finalHeartRateAvg = finalAvg, isLie = result) }
             postSideEffect(DdoLieSideEffect.NavigateToResult)
+            stopPrewarm()
         }
     }
 
@@ -146,6 +200,11 @@ class DdoLieViewModel(
         val finalScore = (heartRateScore * 0.6f) + (randomFactor * 0.4f)
 
         // 4. 판정 (임계값 0.5)
-        return if (finalScore >= 0.5f) LieResult.LIE else LieResult.TRUTH
+        val result = if (finalScore >= 0.5f) LieResult.LIE else LieResult.TRUTH
+        Log.d(
+            TAG,
+            "[3/3] 결과 - diff=$diff, hrScore=$heartRateScore, random=$randomFactor, finalScore=$finalScore, verdict=$result",
+        )
+        return result
     }
 }

--- a/app/src/main/java/com/haeti/ddolie/presentation/init/InitialScreen.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/init/InitialScreen.kt
@@ -1,8 +1,14 @@
 package com.haeti.ddolie.presentation.init
 
 import android.Manifest
-import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.animateValue
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.foundation.Canvas
@@ -52,15 +58,35 @@ fun InitialScreen(
     navController: NavController,
     viewModel: DdoLieViewModel,
 ) {
-    val permissionState = rememberPermissionState(
-        permission = Manifest.permission.BODY_SENSORS,
-        onPermissionResult = { granted ->
-            Log.e("InitialScreen", "Permission granted: $granted")
-        }
-    )
+    val permissionState = rememberPermissionState(Manifest.permission.BODY_SENSORS)
 
     var isMeasuring by remember { mutableStateOf(false) }
-    var activeCircleIndex by remember { mutableIntStateOf(0) }
+    var circleStarted by remember { mutableStateOf(false) }
+
+    LaunchedEffect(isMeasuring) {
+        if (isMeasuring) {
+            delay(Animation.FADE_TRANSITION_MS.toLong())
+            circleStarted = true
+        } else {
+            circleStarted = false
+        }
+    }
+
+    val infiniteTransition = rememberInfiniteTransition(label = "initialCircle")
+    val animatedCircleIndex by infiniteTransition.animateValue(
+        initialValue = 0,
+        targetValue = 8,
+        typeConverter = Int.VectorConverter,
+        animationSpec = infiniteRepeatable(
+            animation = tween(
+                durationMillis = Animation.INITIAL_CIRCLE_CYCLE_MS,
+                easing = LinearEasing,
+            ),
+            repeatMode = RepeatMode.Restart,
+        ),
+        label = "initialCircleIndex",
+    )
+    val activeCircleIndex = if (circleStarted) animatedCircleIndex % 8 else -1
 
     val activeCircleColor = Color(0xFFF44522)
     val inactiveCircleColor = Color(0xFF333333)
@@ -81,19 +107,6 @@ fun InitialScreen(
 
                 else -> {}
             }
-        }
-    }
-
-    LaunchedEffect(isMeasuring) {
-        Log.e("InitialScreen", "isMeasuring: $isMeasuring")
-        if (isMeasuring) {
-            repeat(Animation.INITIAL_SCREEN_ANIMATION_CYCLES) {
-                repeat(Animation.INITIAL_SCREEN_CYCLE_STEPS) {
-                    activeCircleIndex = it
-                    delay(Animation.INITIAL_SCREEN_STEP_DELAY)
-                }
-            }
-            // TODO : 측정 완료 로직 추가
         }
     }
 
@@ -122,8 +135,8 @@ fun InitialScreen(
 
         AnimatedVisibility(
             visible = !isMeasuring,
-            enter = fadeIn(),
-            exit = fadeOut()
+            enter = fadeIn(animationSpec = tween(Animation.FADE_TRANSITION_MS)),
+            exit = fadeOut(animationSpec = tween(Animation.FADE_TRANSITION_MS)),
         ) {
             Column(
                 modifier = Modifier.fillMaxSize(),
@@ -152,18 +165,16 @@ fun InitialScreen(
 
         AnimatedVisibility(
             visible = isMeasuring,
-            enter = fadeIn(),
-            exit = fadeOut()
+            enter = fadeIn(animationSpec = tween(Animation.FADE_TRANSITION_MS)),
+            exit = fadeOut(animationSpec = tween(Animation.FADE_TRANSITION_MS)),
         ) {
             val dotPhases = listOf(".", "..", "...")
             var dotPhaseIndex by remember { mutableIntStateOf(0) }
 
-            LaunchedEffect(isMeasuring) {
-                if (isMeasuring) {
-                    repeat(12) {
-                        dotPhaseIndex = (dotPhaseIndex + 1) % Animation.DOT_PHASES_COUNT
-                        delay(Animation.DOT_ANIMATION_DELAY)
-                    }
+            LaunchedEffect(circleStarted) {
+                while (circleStarted) {
+                    dotPhaseIndex = (dotPhaseIndex + 1) % Animation.DOT_PHASES_COUNT
+                    delay(Animation.DOT_ANIMATION_DELAY)
                 }
             }
 
@@ -185,5 +196,6 @@ fun InitialScreen(
                 )
             }
         }
+
     }
 }

--- a/app/src/main/java/com/haeti/ddolie/presentation/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/navigation/AppNavHost.kt
@@ -34,7 +34,7 @@ fun AppNavHost(
             navController = navigator.navController,
             startDestination = navigator.startDestination,
         ) {
-            addStartGraph(navController)
+            addStartGraph(navController = navController, viewModel = viewModel)
             addInitialGraph(navController = navController, viewModel = viewModel)
             addVoiceRecognitionGraph(navController = navController, viewModel = viewModel)
             addAnalysisGraph(navController = navController, viewModel = viewModel)

--- a/app/src/main/java/com/haeti/ddolie/presentation/start/StartScreen.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/start/StartScreen.kt
@@ -1,7 +1,7 @@
 package com.haeti.ddolie.presentation.start
 
+import android.Manifest
 import android.annotation.SuppressLint
-import android.content.res.Configuration
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
@@ -14,24 +14,24 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
 import androidx.navigation.NavController
-import androidx.navigation.compose.rememberNavController
 import androidx.wear.compose.material.Text
-import androidx.wear.compose.ui.tooling.preview.WearPreviewDevices
 import com.haeti.ddolie.R
 import com.haeti.ddolie.presentation.common.util.toTextDp
+import com.haeti.ddolie.presentation.common.viewmodel.DdoLieViewModel
 import com.haeti.ddolie.presentation.init.navigation.InitialRoute
-import com.haeti.ddolie.presentation.theme.DdoLieTheme
 import com.haeti.ddolie.presentation.theme.RedPrimary
 import com.haeti.ddolie.presentation.theme.RedSecondary
 import com.haeti.ddolie.presentation.theme.RedTertiary
@@ -40,7 +40,18 @@ import com.haeti.ddolie.presentation.theme.RedTertiary
 @Composable
 fun StartScreen(
     navController: NavController,
+    viewModel: DdoLieViewModel,
 ) {
+    val context = LocalContext.current
+    DisposableEffect(Unit) {
+        val granted = ContextCompat.checkSelfPermission(
+            context,
+            Manifest.permission.BODY_SENSORS,
+        ) == android.content.pm.PackageManager.PERMISSION_GRANTED
+        if (granted) viewModel.startPrewarm()
+        onDispose { viewModel.stopPrewarm() }
+    }
+
     BoxWithConstraints(
         modifier = Modifier
             .fillMaxSize()
@@ -54,14 +65,14 @@ fun StartScreen(
 
         val scale = screenWidthDp / baseWidthDp
 
-        val baseImageWidth  = 108.dp
+        val baseImageWidth = 108.dp
         val baseImageHeight = 70.dp
-        val imageWidth  = baseImageWidth  * scale
+        val imageWidth = baseImageWidth * scale
         val imageHeight = baseImageHeight * scale
 
-        val baseFontSize  = 15.toTextDp
+        val baseFontSize = 15.toTextDp
         val baseLineHeight = 23.toTextDp
-        val fontSize   = baseFontSize * scale
+        val fontSize = baseFontSize * scale
         val lineHeight = baseLineHeight * scale
 
         val baseSpacer = 10.dp
@@ -115,17 +126,3 @@ fun StartScreen(
     }
 }
 
-@WearPreviewDevices
-@Preview(
-    name = "40mm – 396×396px",
-    device = "spec:width=396px,height=396px,dpi=330", // 40mm 모델 테스트
-    uiMode = Configuration.UI_MODE_TYPE_WATCH,
-    showSystemUi = false,
-    showBackground = false
-)
-@Composable
-fun PreviewStartScreen() {
-    DdoLieTheme {
-        StartScreen(navController = rememberNavController())
-    }
-}

--- a/app/src/main/java/com/haeti/ddolie/presentation/start/navigation/StartNavigation.kt
+++ b/app/src/main/java/com/haeti/ddolie/presentation/start/navigation/StartNavigation.kt
@@ -3,10 +3,14 @@ package com.haeti.ddolie.presentation.start.navigation
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
+import com.haeti.ddolie.presentation.common.viewmodel.DdoLieViewModel
 import com.haeti.ddolie.presentation.start.StartScreen
 
-fun NavGraphBuilder.addStartGraph(navController: NavController) {
+fun NavGraphBuilder.addStartGraph(
+    navController: NavController,
+    viewModel: DdoLieViewModel,
+) {
     composable<StartRoute.Main> {
-        StartScreen(navController)
+        StartScreen(navController = navController, viewModel = viewModel)
     }
 }


### PR DESCRIPTION
## Summary
Galaxy Watch 4 환경에서 심박수 측정이 자주 0개로 잡히고 화면 전환·애니메이션이 끊기던 문제를 해결.

## Description

- **Sensor 등록 공유**: `HealthServiceManager`의 `callbackFlow`를 `shareIn(WhileSubscribed 15s)`로 감싸 초기/분석 측정 두 phase가 동일한 Health Services 등록을 공유 → phase 사이 워밍업 반복 제거
- **`runBlocking` 제거**: `awaitClose`의 unregister를 별도 `cleanupScope.launch(NonCancellable)`로 이전 → 메인 스레드 블로킹과 콜백 leak 동시 해결
- **Prewarm 도입**: `StartScreen` 진입 시 권한이 있으면 sensor 미리 워밍업, `DisposableEffect`/`finalizeMeasurement` 종료 시점에 자동 해제 → 첫 측정 phase에서 워밍업 대기 시간 단축
- **Baseline fallback**: 초기 측정이 비어있으면 분석 측정 앞 2개 샘플을 baseline으로 사용 → 첫 사용 시 GW4 워밍업이 길어도 결과 산출 가능
- **애니메이션 교체**: `InitialScreen`의 수동 `delay` 루프를 `rememberInfiniteTransition` + `animateValue`로 변경, 텍스트 fade(400ms) 후 원/점 애니가 시작되도록 동기화
- **Constants 정비**: `INITIAL_MEASUREMENT_TIMEOUT` 5초로 조정, `FADE_TRANSITION_MS` / `INITIAL_CIRCLE_CYCLE_MS` 추가
- **진단 로그 정비**: `DdoLieFlow` 태그로 `[1/3] 초기 측정`, `[2/3] 분석 측정`, `[3/3] 결과` + sensor availability 흐름만 남김
- **versionCode 2 / versionName 1.1** bump
- **`.gitignore`**: `.omc/`, `app/release/`, `*.jks`, `.idea/markdown.xml` 추가 (keystore·빌드 산출물 방지)

## Test plan

- [ ] StartScreen → InitialScreen 전환 시 끊김 없는지 확인
- [ ] 초기 측정에서 BPM 샘플 ≥ 1개 수집되는지 logcat (`adb logcat -s DdoLieFlow`)으로 확인
- [ ] 분석 측정 완료 후 결과 화면이 정상적으로 노출되는지 확인
- [ ] 다시하기 → 재측정 시 이전 데이터가 섞이지 않는지 확인
- [ ] 결과 화면 진입 후 15초 이상 머무를 때 sensor unregister 로그 확인